### PR TITLE
Afk command

### DIFF
--- a/bot-commands.js
+++ b/bot-commands.js
@@ -521,6 +521,14 @@ async function HandleTranscriptCommand(discordMessage) {
 const sentToAFkTimes = {};
 
 async function HandleAfkCommand(discordMessage) {
+	const authorId = discordMessage.author.id;
+    const author = await UserCache.GetCachedUserByDiscordId(authorId);
+	if (author.rank > 5) {
+		await discordMessage.channel.send(
+			`Error: Only generals can do that.`
+		)
+		return
+	}
 	const mentionedMember = await DiscordUtil.ParseExactlyOneMentionedDiscordMember(discordMessage);
 	if (!mentionedMember) {
 		await discordMessage.channel.send(

--- a/bot-commands.js
+++ b/bot-commands.js
@@ -523,7 +523,7 @@ const sentToAFkTimes = {};
 async function HandleAfkCommand(discordMessage) {
 	const authorId = discordMessage.author.id;
     const author = await UserCache.GetCachedUserByDiscordId(authorId);
-	if (author.rank > 5) {
+	if (author.rank > 5 || author == null) {
 		await discordMessage.channel.send(
 			`Error: Only generals can do that.`
 		)

--- a/bot-commands.js
+++ b/bot-commands.js
@@ -542,7 +542,7 @@ async function HandleAfkCommand(discordMessage) {
 	const diff = Math.abs(new Date().getTime() - memberSentTime);
 	const minutesSinceSentToAfk = Math.floor((diff/1000)/60);
 	
-	if (minutesSinceSentToAfk < 10) {
+	if (minutesSinceSentToAfk < 30) {
 		await discordMessage.channel.send(
 			`${mentionedMember.nickname} cannot be sent to idle lounge more than once every 10 minutes.`
 		);

--- a/bot-commands.js
+++ b/bot-commands.js
@@ -544,7 +544,7 @@ async function HandleAfkCommand(discordMessage) {
 	
 	if (minutesSinceSentToAfk < 10) {
 		await discordMessage.channel.send(
-			`${mentionedMember.nickname} cannot be sent to idle lounge more than once, every 10 minutes.`
+			`${mentionedMember.nickname} cannot be sent to idle lounge more than once every 10 minutes.`
 		);
 		return;
 	}

--- a/bot-commands.js
+++ b/bot-commands.js
@@ -544,7 +544,7 @@ async function HandleAfkCommand(discordMessage) {
 	
 	if (minutesSinceSentToAfk < 10) {
 		await discordMessage.channel.send(
-			`Error: ${mentionedMember.nickname} cannot be sent to idle lounge more than once, every 10 minutes.`
+			`${mentionedMember.nickname} cannot be sent to idle lounge more than once, every 10 minutes.`
 		);
 		return;
 	}

--- a/bot-commands.js
+++ b/bot-commands.js
@@ -538,8 +538,8 @@ async function HandleAfkCommand(discordMessage) {
 		return;
 	}
 	
-	
-	const diff = Math.abs(new Date() - sentToAFkTimes[mentionedMember] || 0);
+	const memberSentTime = sentToAFkTimes[mentionedMember] || 0
+	const diff = Math.abs(new Date().getTime() - memberSentTime);
 	const minutesSinceSentToAfk = Math.floor((diff/1000)/60);
 	
 	if (minutesSinceSentToAfk < 10) {
@@ -554,7 +554,7 @@ async function HandleAfkCommand(discordMessage) {
 	} catch(e) {
 		throw new Error(e);
 	} finally {
-		sentToAFkTimes[memberId] = new Date();
+		sentToAFkTimes[memberId] = new Date().getTime();
 	}
 }
 

--- a/bot-commands.js
+++ b/bot-commands.js
@@ -538,9 +538,10 @@ async function HandleAfkCommand(discordMessage) {
 		return;
 	}
 	
-	const diff = Math.abs(new Date() - sentToAFkTimes[mentionedMember]);
+	
+	const diff = Math.abs(new Date() - sentToAFkTimes[mentionedMember] || 0);
 	const minutesSinceSentToAfk = Math.floor((diff/1000)/60);
-
+	
 	if (minutesSinceSentToAfk < 10) {
 		await discordMessage.channel.send(
 			`Error: ${mentionedMember.nickname} cannot be sent to AFK channel more than once, every 10 minutes.`

--- a/bot-commands.js
+++ b/bot-commands.js
@@ -538,13 +538,13 @@ async function HandleAfkCommand(discordMessage) {
 		return;
 	}
 	
-	const memberSentTime = sentToAFkTimes[mentionedMember.id] || 0
+	const memberSentTime = sentToAFkTimes[mentionedMember.id] || 0;
 	const diff = Math.abs(new Date().getTime() - memberSentTime);
 	const minutesSinceSentToAfk = Math.floor((diff/1000)/60);
 	
 	if (minutesSinceSentToAfk < 10) {
 		await discordMessage.channel.send(
-			`Error: ${mentionedMember.nickname} cannot be sent to AFK channel more than once, every 10 minutes.`
+			`Error: ${mentionedMember.nickname} cannot be sent to idle lounge more than once, every 10 minutes.`
 		);
 		return;
 	}
@@ -552,6 +552,13 @@ async function HandleAfkCommand(discordMessage) {
 	try {
 		await DiscordUtil.moveMemberToAfk(mentionedMember);
 	} catch(e) {
+		// Note: Error code for member no in voice channel.
+		if (e.code === 40032) {
+			await discordMessage.channel.send(
+				`${mentionedMember.nickname} is not in a voice channel, cannot be sent to idle lounge.`
+			);
+			return;
+		}
 		throw new Error(e);
 	} finally {
 		sentToAFkTimes[mentionedMember.id] = new Date().getTime();

--- a/bot-commands.js
+++ b/bot-commands.js
@@ -550,11 +550,11 @@ async function HandleAfkCommand(discordMessage) {
 	}
 
 	try {
-		await DiscordUtil.moveMemberToAfk(mentionedMember)
+		await DiscordUtil.moveMemberToAfk(mentionedMember);
 	} catch(e) {
-		throw new Error(e)
+		throw new Error(e);
 	} finally {
-		sentToAFkTimes[memberId] = new Date()
+		sentToAFkTimes[memberId] = new Date();
 	}
 }
 

--- a/bot-commands.js
+++ b/bot-commands.js
@@ -552,7 +552,7 @@ async function HandleAfkCommand(discordMessage) {
 	try {
 		await DiscordUtil.moveMemberToAfk(mentionedMember);
 	} catch(e) {
-		// Note: Error code for member no in voice channel.
+		// Note: Error code for member not in voice channel.
 		if (e.code === 40032) {
 			await discordMessage.channel.send(
 				`${mentionedMember.nickname} is not in a voice channel, cannot be sent to idle lounge.`

--- a/bot-commands.js
+++ b/bot-commands.js
@@ -538,7 +538,7 @@ async function HandleAfkCommand(discordMessage) {
 		return;
 	}
 	
-	const memberSentTime = sentToAFkTimes[mentionedMember] || 0
+	const memberSentTime = sentToAFkTimes[mentionedMember.id] || 0
 	const diff = Math.abs(new Date().getTime() - memberSentTime);
 	const minutesSinceSentToAfk = Math.floor((diff/1000)/60);
 	
@@ -554,7 +554,7 @@ async function HandleAfkCommand(discordMessage) {
 	} catch(e) {
 		throw new Error(e);
 	} finally {
-		sentToAFkTimes[memberId] = new Date().getTime();
+		sentToAFkTimes[mentionedMember.id] = new Date().getTime();
 	}
 }
 

--- a/bot-commands.js
+++ b/bot-commands.js
@@ -523,7 +523,7 @@ const sentToAFkTimes = {};
 async function HandleAfkCommand(discordMessage) {
 	const authorId = discordMessage.author.id;
     const author = await UserCache.GetCachedUserByDiscordId(authorId);
-	if (author.rank > 5 || author == null) {
+	if (!author || author.rank > 5) {
 		await discordMessage.channel.send(
 			`Error: Only generals can do that.`
 		)

--- a/bot-commands.js
+++ b/bot-commands.js
@@ -544,7 +544,7 @@ async function HandleAfkCommand(discordMessage) {
 	
 	if (minutesSinceSentToAfk < 30) {
 		await discordMessage.channel.send(
-			`${mentionedMember.nickname} cannot be sent to idle lounge more than once every 10 minutes.`
+			`${mentionedMember.nickname} cannot be sent to idle lounge more than once every 30 minutes.`
 		);
 		return;
 	}

--- a/discord-util.js
+++ b/discord-util.js
@@ -269,6 +269,12 @@ async function DeleteMessagesByMember(member, maxAgeInSeconds) {
     delete membersWithOngoingMessageDeletion[member.id];
 }
 
+async function moveMemberToAfk(member) {
+    const afkLoungeId = '703716669452714054';
+    await member.voice.setChannel(afkLoungeId, `${member.nickname} has been sent to the AFK channel.`);
+    return;
+}
+
 module.exports = {
     AddRole,
     Connect,
@@ -285,4 +291,5 @@ module.exports = {
     RemoveRole,
     SendLongList,
     UpdateHarmonicCentralityChatChannel,
+    moveMemberToAfk
 };


### PR DESCRIPTION
AFK Command allows Generals to send a user to the AFK channel once every 30 minutes if the user is AFK. 

This will prevent the need to use the ban court to remove AFK players from a channel. Reducing friction/drama within a community. 
