### PR TITLE
Change rank modifier from 1.33 to 1.00

### DIFF
--- a/harmonic-centrality.js
+++ b/harmonic-centrality.js
@@ -77,7 +77,7 @@ function ConvertDistanceMatrixToHarmonicCentrality(d, candidates) {
 		c += 1 / GetDistance(d, i, j);
 	    }
 	});
-	h[i] = c * 1.33;
+	h[i] = c * 1.00;
     });
     return h;
 }


### PR DESCRIPTION
The rank values are currently being artificially inflated by a value of 1.33. What this means is that lower ranks see their points rise relatively slowly, and the point values become disproportionately top-heavy. This modifier was originally added as a temporary measure to stop points from deflating too much during a code optimization update a few months ago.

My proposed change will switch the modifier back to 1.00 so that users' actual point values show up.

CURRENT RANKS (1.33 modifier applied; displaying inflated value)
43,454 Mr. Vice President ⚑
38,340 Nikki ★
26,521 The President ⚑
18,876 Scarrab ★
13,693 nex ❱❱❱
6,746 ThePi ⦁⦁⦁⦁
1,119 Tentacle Monster ⦁⦁⦁

PROPOSED RANKS (1.00 modifier applied; displaying actual value)
32,672 Mr. Vice President ⚑
28,827 Nikki ★
19,940 The President ⚑
14,192 Scarrab ★
10,295 nex ❱❱❱
5,072 ThePi ⦁⦁⦁⦁
841 Tentacle Monster ⦁⦁⦁