### PR TITLE
Urgent Security Fix

### DIFF
--- a/.voters.yml
+++ b/.voters.yml
@@ -1,5 +1,4 @@
 ---
-donatarigov: 1
 j3camero: 1
 Koof91: 1
 Scarrab: 1


### PR DESCRIPTION
Last night Aperture (donatarigov) force-merged a code change, bypassing the vote-based system. This is the equivalent of Jeff right-click banning someone in Discord before their trial in Ban Court has completed, bypassing the voters.

This is his 2nd offense. The first time he did it I explained to him that even though he has admin access to the repo and can therefore force-merge any PR bypassing the voters, that this is a loophole and should not be done. This rules out that he somehow didn't know or realize. He knows damn well. None of the other voters have ever done this. They all know better. So does Aperture.

He did it in the dead of night, at 2:30 AM Eastern.

He himself was part of the original voters who agreed on a 24h minimum time to pass any code change. The time limit is enforced automatically by a GitHub Action that we installed called "democracy". Aperture abused his admin powers to bypass this system.

One of the first things we did after the vote-based system was installed was to set the 24h minimum. It stops people from passing a PR in the middle of the night. It creates a relaxed non-tactical atmosphere where voters get that guaranteed 24h to consider their vote, change their mind, suggest changes, etc. Just like the minimum timer in Ban Court. It stops 3 voters from banning someone in the dead of night.

Question: "could this have been a mistake? Maybe he unknowingly slipped up"
Answer: unfortunately it's not possible. When the automated checks including the vote system are all in a passing state, the Merge button turns bright green and gets larger. It's extremely salient. To bypass the voting system, he had had to click a small greyed out Merge button with a red X near it. He then had to click through a secondary warning that warns him the checks haven't passed yet. There's no possibility this was an accident.

Question: is this just pedantic rule enforcement? Does this actually matter?
Answer: Yes! The problem with someone who shows they won't respect the 24h minimum is he could pass a change that adds discord.delete() in the dead of night. 10 seconds later the change would be auto-deployed and the entire discord would be permanently deleted forever. By the time other voters got up in the morning to vote against the change, it would be too late. This is therefore an URGENT security matter.
