### PR TITLE
Revert "Added Baggy to voters."

### DIFF
--- a/.voters.yml
+++ b/.voters.yml
@@ -4,4 +4,3 @@ j3camero: 1
 Koof91: 1
 Scarrab: 1
 C-Ekkos: 1
-Bagdadcowboy: 1


### PR DESCRIPTION
Sorry Baggy. The PR that was supposed to add you as a voter was invalidated when Aperture used admin powers to forcibly merge it, bypassing the vote-based system. I will raise another one to get it done legally.